### PR TITLE
Fix/APIC-620/extra empty space

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advanced-rest-client/prism-highlight",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@advanced-rest-client/prism-highlight",
   "description": "Syntax highlighting via Prism",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/PrismStyles.js
+++ b/src/PrismStyles.js
@@ -140,4 +140,8 @@ export default css`
   .token.entity {
     cursor: help;
   }
+  
+  .parsed-content {
+    display: table;
+  }
 `;


### PR DESCRIPTION
APIC-620 bug: Examples showing extra spaces

Before:
<img width="764" alt="Screen Shot 2021-04-27 at 12 02 28 PM" src="https://user-images.githubusercontent.com/13999213/116264279-8d03f080-a750-11eb-9bc9-545e60a79e00.png">

After:
<img width="764" alt="Screen Shot 2021-04-27 at 12 02 47 PM" src="https://user-images.githubusercontent.com/13999213/116264272-8bd2c380-a750-11eb-95fa-02d1131cab3b.png">
